### PR TITLE
chore(flux): right-size kustomize-controller resources (KRR)

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -57,7 +57,27 @@ spec:
                             memory: 1Gi
             target:
               kind: Deployment
-              name: (kustomize-controller|helm-controller|source-controller)
+              name: (helm-controller|source-controller)
+          - # Right-size kustomize-controller resources based on KRR recommendations
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: kustomize-controller
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: manager
+                        resources:
+                          requests:
+                            cpu: 10m
+                            memory: 123Mi
+                          limits:
+                            memory: 123Mi
+            target:
+              kind: Deployment
+              name: kustomize-controller
           - # Enable in-memory kustomize builds
             patch: |
               - op: add


### PR DESCRIPTION
## Summary

Right-size `kustomize-controller` resources based on KRR (Kubernetes Resource Recommendations) analysis.

## Scaling Strategy: Static Resource Update

**Why not HPA/VPA/KEDA?**
- `kustomize-controller` runs as a **singleton with leader election** (`--enable-leader-election`)
- Horizontal scaling provides no benefit for this controller pattern
- Resource usage is stable and predictable — no bursty traffic patterns
- VPA adds operational complexity with no real advantage for a stable workload
- KEDA is designed for event-driven scaling, not applicable here

## Resource Changes (container: `manager`)

| Resource | Before | After | Rationale |
|----------|--------|-------|-----------|
| CPU request | 100m | 10m | 95th percentile usage is ~5m |
| CPU limit | 1000m | _(removed)_ | Allow bursting for occasional spikes (~35m) |
| Memory request | 64Mi | 123Mi | Peak usage ~112Mi + 15% buffer |
| Memory limit | 1Gi | 123Mi | Aligned with request; prevents over-commitment |

## Evidence (last 24h metrics)

- **CPU**: Typically 1–5m, occasional reconciliation spikes to ~35m
- **Memory**: 63–117Mi working set, peak 112Mi

## Implementation Details

- Separated `kustomize-controller` from the shared memory limits patch (which still applies 1Gi to `helm-controller` and `source-controller`)
- Added a dedicated strategic merge patch for `kustomize-controller` resources
- The `GOMEMLIMIT` env var uses `resourceFieldRef: limits.memory`, so it auto-adjusts to 123Mi

## ⚠️ Risk Note

Memory limit = request = 123Mi means no headroom beyond the 15% buffer. If reconciliation of a large kustomization pushes memory above 123Mi, the pod will be OOMKilled (and restarted). Monitor for OOMKill events after merging.
