### PR TITLE
chore(flux): remove CPU limit for kustomize-controller

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -78,6 +78,13 @@ spec:
             target:
               kind: Deployment
               name: kustomize-controller
+          - # Remove CPU limit for kustomize-controller to prevent throttling during reconciliation bursts
+            patch: |
+              - op: remove
+                path: /spec/template/spec/containers/0/resources/limits/cpu
+            target:
+              kind: Deployment
+              name: kustomize-controller
           - # Enable in-memory kustomize builds
             patch: |
               - op: add


### PR DESCRIPTION
## Summary

Remove CPU limit for `kustomize-controller` (container `manager`) to prevent throttling during reconciliation bursts.

## Scaling Strategy: Static Resource Update

**Why not HPA/VPA/KEDA?**
- Single-replica controller with `--enable-leader-election` — horizontal scaling is not applicable
- Predictable, low-utilization workload — VPA adds unnecessary complexity
- No event-driven scaling triggers — KEDA has no applicable scalers

## Resource Changes

| Resource | Before | After |
|----------|--------|-------|
| CPU request | 100m → 10m | 10m *(already applied)* |
| CPU limit | 1000m | **none** ← this PR |
| Memory request | 64Mi → 123Mi | 123Mi *(already applied)* |
| Memory limit | 1024Mi → 123Mi | 123Mi *(already applied)* |

## Evidence (24h Prometheus + KRR)

**CPU usage**: Typically 1-10m with brief reconciliation spikes up to ~250m. The 1000m CPU limit could throttle these bursts.

**Memory usage**: Steady state 55-110 MiB, max observed ~110 MiB. The 123Mi limit provides ~12% headroom and is guarded by `GOMEMLIMIT` env var.

**KRR recommendation**: CPU request 10m, no CPU limit; Memory request/limit ~123Mi.

## Implementation

Added a JSON patch (`op: remove`) targeting `/spec/template/spec/containers/0/resources/limits/cpu` on the kustomize-controller Deployment. This removes the CPU limit inherited from the flux-operator base manifests while keeping the memory limit intact.

## Risk Assessment

- **Low risk**: Removing CPU limit on a burstable QoS pod allows brief CPU bursts during reconciliation without affecting other workloads (CPU request remains at 10m for scheduler accounting)
- **Memory bounded**: `GOMEMLIMIT` is derived from `limits.memory`, ensuring Go GC respects the 123Mi boundary
- **Rollback**: Revert this PR to restore the 1000m CPU limit